### PR TITLE
Refactor: Remove Hero.role, Hero.type

### DIFF
--- a/api/src/hero.js
+++ b/api/src/hero.js
@@ -17,7 +17,6 @@ const Hero = module.exports = class Hero {
    * @param {string=} o.icon
    * @param {string=} o.iconUrl
    * @param {string=} o.id
-   * @param {string=} o.type
    * @param {string=} o.newRole
    * @param {string=} o.universe
    * @param {HeroStats | HeroStats[]} o.stats
@@ -31,7 +30,6 @@ const Hero = module.exports = class Hero {
     this.icon = o.icon || '';
     this.iconUrl = o.iconUrl || '';
     this.id = o.id || '';
-    this.type = o.type || '';
     this.newRole = o.newRole || '';
     this.universe = o.universe || '';
 
@@ -98,7 +96,6 @@ const Hero = module.exports = class Hero {
       icon: this.icon || undefined,
       iconUrl: this.iconUrl || undefined,
       id: this.id,
-      type: this.type,
       newRole: this.newRole,
       universe: this.universe,
       stats: this.stats,

--- a/api/src/merge-hots-data.js
+++ b/api/src/merge-hots-data.js
@@ -70,7 +70,6 @@ function mergeHero(target, source) {
     name: 0,
     title: 0,
     icon: 0,
-    type: 0,
     universe: 0,
   });
 

--- a/api/tests/input/heroes.json
+++ b/api/tests/input/heroes.json
@@ -269,7 +269,6 @@
   "abathur": {
     "name": "아바투르",
     "title": "",
-    "type": "근접",
     "newRole": "support",
     "universe": "starcraft",
     "stats": {
@@ -591,7 +590,6 @@
     "name": "초",
     "title": "",
     "iconUrl": "http://i3.ruliweb.com/img/18/06/14/163fc22380a19dc2c.png",
-    "type": "근접",
     "newRole": "tank",
     "universe": "warcraft",
     "stats": {
@@ -835,7 +833,6 @@
     "name": "갈",
     "title": "",
     "iconUrl": "http://i2.ruliweb.com/img/18/06/14/163fc22803219dc2c.png",
-    "type": "원거리",
     "newRole": "ranged_assassin",
     "universe": "warcraft",
     "stats": {

--- a/chrome-ext/tests/data/hots.json
+++ b/chrome-ext/tests/data/hots.json
@@ -5,7 +5,6 @@
       "name": "피닉스",
       "title": "기사단의 귀감",
       "icon": "ui_targetportrait_hero_fenix",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -388,7 +387,6 @@
       "name": "렉사르",
       "title": "호드의 용사",
       "icon": "ui_targetportrait_hero_rexxar",
-      "type": "원거리",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": [
@@ -766,7 +764,6 @@
       "name": "가즈로",
       "title": "톱니항 두목",
       "icon": "ui_targetportrait_hero_gazlowe",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "warcraft",
       "stats": {

--- a/docs/hots-schema.json
+++ b/docs/hots-schema.json
@@ -80,14 +80,6 @@
         "icon": {
           "$ref": "#/definitions/iconId"
         },
-        "type": {
-          "type": "string",
-          "enum": [
-            "근접",
-            "원거리",
-            "근접 / 원거리"
-          ]
-        },
         "newRole": {
           "enum": [
             "tank",
@@ -174,7 +166,6 @@
       },
       "required": [
         "name",
-        "type",
         "icon",
         "newRole",
         "universe",

--- a/docs/hots.json
+++ b/docs/hots.json
@@ -5,7 +5,6 @@
       "name": "아바투르",
       "title": "진화 군주",
       "icon": "ui_targetportrait_hero_abathur",
-      "type": "근접",
       "newRole": "support",
       "universe": "starcraft",
       "stats": {
@@ -453,7 +452,6 @@
       "name": "알라라크",
       "title": "탈다림의 군주",
       "icon": "ui_targetportrait_hero_alarak",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "starcraft",
       "stats": {
@@ -842,7 +840,6 @@
       "name": "알렉스트라자",
       "title": "생명의 어머니",
       "icon": "ui_targetportrait_hero_alexstrasza",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": [
@@ -1306,7 +1303,6 @@
       "name": "카시아",
       "title": "아마존 여군주",
       "icon": "ui_targetportrait_hero_d2amazonf",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "diablo",
       "stats": {
@@ -1677,7 +1673,6 @@
       "name": "아나",
       "title": "노련한 저격수",
       "icon": "ui_targetportrait_hero_ana",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "overwatch",
       "stats": {
@@ -2056,7 +2051,6 @@
       "name": "안두인",
       "title": "스톰윈드 국왕",
       "icon": "ui_targetportrait_hero_anduin",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -2459,7 +2453,6 @@
       "name": "아눕아락",
       "title": "배신자 왕",
       "icon": "ui_targetportrait_hero_anubarak",
-      "type": "근접",
       "newRole": "tank",
       "universe": "warcraft",
       "stats": {
@@ -2845,7 +2838,6 @@
       "name": "아르타니스",
       "title": "댈람의 신관",
       "icon": "ui_targetportrait_hero_artanis",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "starcraft",
       "stats": {
@@ -3245,7 +3237,6 @@
       "name": "아서스",
       "title": "리치 왕",
       "icon": "ui_targetportrait_hero_arthas",
-      "type": "근접",
       "newRole": "tank",
       "universe": "warcraft",
       "stats": {
@@ -3621,7 +3612,6 @@
       "name": "아우리엘",
       "title": "희망의 대천사",
       "icon": "ui_targetportrait_hero_auriel",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "diablo",
       "stats": {
@@ -4007,7 +3997,6 @@
       "name": "아즈모단",
       "title": "죄악의 군주",
       "icon": "ui_targetportrait_hero_azmodan",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "diablo",
       "stats": {
@@ -4380,7 +4369,6 @@
       "name": "소냐",
       "title": "떠도는 야만용사",
       "icon": "ui_targetportrait_hero_barbarian",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "diablo",
       "stats": {
@@ -4739,7 +4727,6 @@
       "name": "도살자",
       "title": "고기 해체자",
       "icon": "ui_targetportrait_hero_butcher",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "diablo",
       "stats": {
@@ -5113,7 +5100,6 @@
       "name": "첸",
       "title": "전설의 양조사",
       "icon": "ui_targetportrait_hero_chen",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": {
@@ -5537,7 +5523,6 @@
       "name": "초",
       "title": "황혼의 망치단 족장",
       "icon": "ui_targetportrait_hero_cho",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": {
@@ -5903,7 +5888,6 @@
       "name": "크로미",
       "title": "시간의 수호자",
       "icon": "ui_targetportrait_hero_chromie",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -6288,7 +6272,6 @@
       "name": "요한나",
       "title": "자카룸의 성전사",
       "icon": "ui_targetportrait_hero_johanna",
-      "type": "근접",
       "newRole": "tank",
       "universe": "diablo",
       "stats": {
@@ -6669,7 +6652,6 @@
       "name": "D.Va",
       "title": "MEKA 조종사",
       "icon": "ui_targetportrait_hero_dva",
-      "type": "원거리",
       "newRole": "bruiser",
       "universe": "overwatch",
       "stats": [
@@ -7139,7 +7121,6 @@
       "name": "데커드",
       "title": "마지막 호라드림",
       "icon": "ui_targetportrait_hero_deckard",
-      "type": "근접",
       "newRole": "healer",
       "universe": "diablo",
       "stats": {
@@ -7495,7 +7476,6 @@
       "name": "데하카",
       "title": "원시 무리 우두머리",
       "icon": "ui_targetportrait_hero_dehaka",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "starcraft",
       "stats": {
@@ -7881,7 +7861,6 @@
       "name": "발라",
       "title": "악마사냥꾼",
       "icon": "ui_targetportrait_hero_demonhunter",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "diablo",
       "stats": {
@@ -8261,7 +8240,6 @@
       "name": "디아블로",
       "title": "공포의 군주",
       "icon": "ui_targetportrait_hero_diablo",
-      "type": "근접",
       "newRole": "tank",
       "universe": "diablo",
       "stats": {
@@ -8640,7 +8618,6 @@
       "name": "루나라",
       "title": "세나리우스의 첫 번째 딸",
       "icon": "ui_targetportrait_hero_lunara",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -9052,7 +9029,6 @@
       "name": "빛나래",
       "title": "요정용",
       "icon": "ui_targetportrait_hero_faeriedragon",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -9451,7 +9427,6 @@
       "name": "폴스타트",
       "title": "와일드해머 영주",
       "icon": "ui_targetportrait_hero_falstad",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -9838,7 +9813,6 @@
       "name": "피닉스",
       "title": "기사단의 귀감",
       "icon": "ui_targetportrait_hero_fenix",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -10236,7 +10210,6 @@
       "name": "블레이즈",
       "title": "노련한 화염방사병",
       "icon": "ui_targetportrait_hero_firebat",
-      "type": "원거리",
       "newRole": "tank",
       "universe": "starcraft",
       "stats": {
@@ -10631,7 +10604,6 @@
       "name": "갈",
       "title": "황혼의 망치단 족장",
       "icon": "ui_targetportrait_hero_gall",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -11016,7 +10988,6 @@
       "name": "가로쉬",
       "title": "헬스크림의 아들",
       "icon": "ui_targetportrait_hero_garrosh",
-      "type": "근접",
       "newRole": "tank",
       "universe": "warcraft",
       "stats": {
@@ -11399,7 +11370,6 @@
       "name": "겐지",
       "title": "사이보그 닌자",
       "icon": "ui_targetportrait_hero_genji",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "overwatch",
       "stats": {
@@ -11794,7 +11764,6 @@
       "name": "그레이메인",
       "title": "늑대인간의 지도자",
       "icon": "ui_targetportrait_hero_genngreymane",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -12220,7 +12189,6 @@
       "name": "굴단",
       "title": "어둠의 화신",
       "icon": "ui_targetportrait_hero_guldan",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -12595,7 +12563,6 @@
       "name": "한조",
       "title": "일급 암살자",
       "icon": "ui_targetportrait_hero_hanzo",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "overwatch",
       "stats": {
@@ -12981,7 +12948,6 @@
       "name": "일리단",
       "title": "배신자",
       "icon": "ui_targetportrait_hero_illidan",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "warcraft",
       "stats": {
@@ -13340,7 +13306,6 @@
       "name": "임페리우스",
       "title": "용기의 대천사",
       "icon": "ui_targetportrait_hero_imperius",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "diablo",
       "stats": {
@@ -13731,7 +13696,6 @@
       "name": "제이나",
       "title": "대마법사",
       "icon": "ui_targetportrait_hero_jaina",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -14122,7 +14086,6 @@
       "name": "정크랫",
       "title": "쓰레기촌 폭파 전문가",
       "icon": "ui_targetportrait_hero_junkrat",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "overwatch",
       "stats": {
@@ -14517,7 +14480,6 @@
       "name": "캘타스",
       "title": "태양왕",
       "icon": "ui_targetportrait_hero_kaelthas",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -14894,7 +14856,6 @@
       "name": "켈투자드",
       "title": "낙스라마스의 고위 리치",
       "icon": "ui_targetportrait_hero_kelthuzad",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -15298,7 +15259,6 @@
       "name": "케리건",
       "title": "칼날 여왕",
       "icon": "ui_targetportrait_hero_kerrigan",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "starcraft",
       "stats": {
@@ -15683,7 +15643,6 @@
       "name": "정예 타우렌 족장",
       "title": "록의 신",
       "icon": "ui_targetportrait_hero_l90etc",
-      "type": "근접",
       "newRole": "tank",
       "universe": "warcraft",
       "stats": {
@@ -16080,7 +16039,6 @@
       "name": "레오릭",
       "title": "해골 왕",
       "icon": "ui_targetportrait_hero_leoric",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "diablo",
       "stats": {
@@ -16502,7 +16460,6 @@
       "name": "리 리",
       "title": "세계 유랑자",
       "icon": "ui_targetportrait_hero_lili",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -16885,7 +16842,6 @@
       "name": "길 잃은 바이킹",
       "title": "답 없는 삼형제",
       "icon": "ui_targetportrait_hero_lostvikings",
-      "type": "근접 / 원거리",
       "newRole": "support",
       "universe": "classic",
       "stats": [
@@ -17345,7 +17301,6 @@
       "name": "루시우",
       "title": "자유의 투사 DJ",
       "icon": "ui_targetportrait_hero_lucio",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "overwatch",
       "stats": {
@@ -17736,7 +17691,6 @@
       "name": "마이에브",
       "title": "감시관",
       "icon": "ui_targetportrait_hero_maiev",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "warcraft",
       "stats": {
@@ -18105,7 +18059,6 @@
       "name": "말가니스",
       "title": "나스레짐 군주",
       "icon": "ui_targetportrait_hero_malganis",
-      "type": "근접",
       "newRole": "tank",
       "universe": "warcraft",
       "stats": {
@@ -18517,7 +18470,6 @@
       "name": "말퓨리온",
       "title": "대드루이드",
       "icon": "ui_targetportrait_hero_malfurion",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -18897,7 +18849,6 @@
       "name": "말티엘",
       "title": "죽음의 화신",
       "icon": "ui_targetportrait_hero_malthael",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "diablo",
       "stats": {
@@ -19283,7 +19234,6 @@
       "name": "모랄레스 중위",
       "title": "전투 의무관",
       "icon": "ui_targetportrait_hero_medic",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "starcraft",
       "stats": {
@@ -19644,7 +19594,6 @@
       "name": "메디브",
       "title": "최후의 수호자",
       "icon": "ui_targetportrait_hero_medivh",
-      "type": "원거리",
       "newRole": "support",
       "universe": "warcraft",
       "stats": {
@@ -20050,7 +19999,6 @@
       "name": "메피스토",
       "title": "증오의 군주",
       "icon": "ui_targetportrait_hero_mephisto",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "diablo",
       "stats": {
@@ -20435,7 +20383,6 @@
       "name": "카라짐",
       "title": "베라다니의 수도사",
       "icon": "ui_targetportrait_hero_monk",
-      "type": "근접",
       "newRole": "healer",
       "universe": "diablo",
       "stats": {
@@ -20819,7 +20766,6 @@
       "name": "무라딘",
       "title": "산왕",
       "icon": "ui_targetportrait_hero_muradin",
-      "type": "근접",
       "newRole": "tank",
       "universe": "warcraft",
       "stats": {
@@ -21195,7 +21141,6 @@
       "name": "머키",
       "title": "아기 멀록",
       "icon": "ui_targetportrait_hero_murky",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "warcraft",
       "stats": {
@@ -21563,7 +21508,6 @@
       "name": "줄",
       "title": "수수께끼의 강령술사",
       "icon": "ui_targetportrait_hero_necromancer",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "diablo",
       "stats": {
@@ -21962,7 +21906,6 @@
       "name": "키히라",
       "title": "정처 없는 현상금 사냥꾼",
       "icon": "ui_targetportrait_hero_nexus2",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "nexus",
       "stats": {
@@ -22318,7 +22261,6 @@
       "name": "노바",
       "title": "자치령 유령",
       "icon": "ui_targetportrait_hero_nova",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -22710,7 +22652,6 @@
       "name": "오르피아",
       "title": "까마귀 궁정의 후예",
       "icon": "ui_targetportrait_hero_orphea",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "nexus",
       "stats": {
@@ -23109,7 +23050,6 @@
       "name": "프로비우스",
       "title": "호기심 많은 탐사정",
       "icon": "ui_targetportrait_hero_probius",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -23508,7 +23448,6 @@
       "name": "라그나로스",
       "title": "불의 군주",
       "icon": "ui_targetportrait_hero_ragnaros",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": {
@@ -23936,7 +23875,6 @@
       "name": "레이너",
       "title": "반란군 사령관",
       "icon": "ui_targetportrait_hero_raynor",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -24305,7 +24243,6 @@
       "name": "레가르",
       "title": "대지 고리회 주술사",
       "icon": "ui_targetportrait_hero_rehgar",
-      "type": "근접",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -24693,7 +24630,6 @@
       "name": "렉사르",
       "title": "호드의 용사",
       "icon": "ui_targetportrait_hero_rexxar",
-      "type": "원거리",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": [
@@ -25097,7 +25033,6 @@
       "name": "사무로",
       "title": "검귀",
       "icon": "ui_targetportrait_hero_samuro",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "warcraft",
       "stats": {
@@ -25450,7 +25385,6 @@
       "name": "해머 상사",
       "title": "공성 전차 전차장",
       "icon": "ui_targetportrait_hero_sgthammer",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -25855,7 +25789,6 @@
       "name": "누더기",
       "title": "어둠골의 공포",
       "icon": "ui_targetportrait_hero_stitches",
-      "type": "근접",
       "newRole": "tank",
       "universe": "warcraft",
       "stats": {
@@ -26253,7 +26186,6 @@
       "name": "스투코프",
       "title": "감염된 제독",
       "icon": "ui_targetportrait_hero_stukov",
-      "type": "근접",
       "newRole": "healer",
       "universe": "starcraft",
       "stats": {
@@ -26664,7 +26596,6 @@
       "name": "실바나스",
       "title": "밴시 여왕",
       "icon": "ui_targetportrait_hero_sylvanas",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {
@@ -27050,7 +26981,6 @@
       "name": "태사다르",
       "title": "기사단의 구원자",
       "icon": "ui_targetportrait_hero_tassadar",
-      "type": "원거리",
       "newRole": "support",
       "universe": "starcraft",
       "stats": {
@@ -27425,7 +27355,6 @@
       "name": "스랄",
       "title": "호드의 대족장",
       "icon": "ui_targetportrait_hero_thrall",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": {
@@ -27799,7 +27728,6 @@
       "name": "가즈로",
       "title": "톱니항 두목",
       "icon": "ui_targetportrait_hero_gazlowe",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "warcraft",
       "stats": {
@@ -28218,7 +28146,6 @@
       "name": "트레이서",
       "title": "오버워치 요원",
       "icon": "ui_targetportrait_hero_tracer",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "overwatch",
       "stats": {
@@ -28586,7 +28513,6 @@
       "name": "타이커스",
       "title": "악명 높은 범죄자",
       "icon": "ui_targetportrait_hero_tychus",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -29005,7 +28931,6 @@
       "name": "티리엘",
       "title": "정의의 대천사",
       "icon": "ui_targetportrait_hero_tyrael",
-      "type": "근접",
       "newRole": "tank",
       "universe": "diablo",
       "stats": {
@@ -29383,7 +29308,6 @@
       "name": "티란데",
       "title": "엘룬의 대여사제",
       "icon": "ui_targetportrait_hero_tyrande",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -29768,7 +29692,6 @@
       "name": "우서",
       "title": "빛의 수호자",
       "icon": "ui_targetportrait_hero_uther",
-      "type": "근접",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -30165,7 +30088,6 @@
       "name": "발리라",
       "title": "무관의 그림자",
       "icon": "ui_targetportrait_hero_valeera",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "warcraft",
       "stats": {
@@ -30597,7 +30519,6 @@
       "name": "바리안",
       "title": "얼라이언스의 국왕",
       "icon": "ui_targetportrait_hero_varian",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": [
@@ -31083,7 +31004,6 @@
       "name": "화이트메인",
       "title": "종교재판관",
       "icon": "ui_targetportrait_hero_whitemane",
-      "type": "원거리",
       "newRole": "healer",
       "universe": "warcraft",
       "stats": {
@@ -31447,7 +31367,6 @@
       "name": "나지보",
       "title": "이교도 부두술사",
       "icon": "ui_targetportrait_hero_witchdoctor",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "diablo",
       "stats": {
@@ -31835,7 +31754,6 @@
       "name": "리밍",
       "title": "반항적인 마법사",
       "icon": "ui_targetportrait_hero_wizard",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "diablo",
       "stats": {
@@ -32233,7 +32151,6 @@
       "name": "이렐",
       "title": "희망의 빛",
       "icon": "ui_targetportrait_hero_yrel",
-      "type": "근접",
       "newRole": "bruiser",
       "universe": "warcraft",
       "stats": {
@@ -32600,7 +32517,6 @@
       "name": "자가라",
       "title": "군단의 무리어미",
       "icon": "ui_targetportrait_hero_zagara",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "starcraft",
       "stats": {
@@ -32979,7 +32895,6 @@
       "name": "자리야",
       "title": "러시아의 수호자",
       "icon": "ui_targetportrait_hero_zarya",
-      "type": "원거리",
       "newRole": "support",
       "universe": "overwatch",
       "stats": {
@@ -33407,7 +33322,6 @@
       "name": "제라툴",
       "title": "암흑 정무관",
       "icon": "ui_targetportrait_hero_zeratul",
-      "type": "근접",
       "newRole": "melee_assassin",
       "universe": "starcraft",
       "stats": {
@@ -33783,7 +33697,6 @@
       "name": "줄진",
       "title": "아마니의 전쟁군주",
       "icon": "ui_targetportrait_hero_zuljin",
-      "type": "원거리",
       "newRole": "ranged_assassin",
       "universe": "warcraft",
       "stats": {


### PR DESCRIPTION
Since the Hero Role Rework, these properties have been superceded by `Hero.newRole`. Since they are not used by the HotsDialog or the HotsBoxes, it's probably safe to remove them now.