### PR TITLE
Fix bug causing context menu not to show in Chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-
+### Fixed
+- Fixed a bug that made the context menu unavailable in Google Chrome.
 
 ## [0.11.0] - 2020-01-07
 ### Changed

--- a/chrome-ext/src/js/init.js
+++ b/chrome-ext/src/js/init.js
@@ -18,11 +18,11 @@ chrome.runtime.onInstalled.addListener(() => {
   // Run only if Google Chrome
   if (typeof browser === 'undefined') {
     chrome.contextMenus.create({
-      'id': 'ruli-context-menu',
-      'title': '히오스 공략툴 열기',
-      'contexts': ['frame'],
-      // Firefox throws an unexpected error on about:blank
-      'documentUrlPatterns': ['about:blank'],
+      id: 'ruli-context-menu',
+      title: '히오스 공략툴 열기',
+      contexts: ['frame'],
+      // Chrome treats iframes with src="" as though they have src="about:blank"
+      documentUrlPatterns: ['about:blank'],
     });
   } else { // Run only if Firefox
     // Firefox does not recognize Ruliweb's WYSIWYG editor as a frame, so create
@@ -31,7 +31,9 @@ chrome.runtime.onInstalled.addListener(() => {
       id: 'ruli-context-menu-test',
       title: '히오스 공략툴 열기',
       contexts: ['editable'],
-      // Use the same patterns used for injecting content scripts
+      // Firefox treats iframes with src="" as though they inherit the URL of
+      // the parent window. Therefore, use the same URL patterns used for
+      // injecting content scripts.
       documentUrlPatterns:
         chrome.runtime.getManifest().content_scripts[0].matches,
     });

--- a/chrome-ext/src/js/init.js
+++ b/chrome-ext/src/js/init.js
@@ -15,18 +15,27 @@ const ALARM_UPDATE_DATA = 'UPDATE_HOTS_DATA';
 
 // Things that should be called only once (when installed)
 chrome.runtime.onInstalled.addListener(() => {
-  chrome.contextMenus.create({
-    'id': 'ruli-context-menu',
-    'title': '히오스 공략툴 열기',
-    'contexts': [
-      // Firefox does not recognize Ruliweb's WYSIWYG editor as a frame.
-      // Therefore, create context menus on all editables instead
-      typeof browser === 'undefined' ? 'frame' : 'editable',
-    ],
-    // Use the same patterns used for injecting content scripts
-    'documentUrlPatterns':
-      chrome.runtime.getManifest().content_scripts[0].matches,
-  });
+  // Run only if Google Chrome
+  if (typeof browser === 'undefined') {
+    chrome.contextMenus.create({
+      'id': 'ruli-context-menu',
+      'title': '히오스 공략툴 열기',
+      'contexts': ['frame'],
+      // Firefox throws an unexpected error on about:blank
+      'documentUrlPatterns': ['about:blank'],
+    });
+  } else { // Run only if Firefox
+    // Firefox does not recognize Ruliweb's WYSIWYG editor as a frame, so create
+    // context menus on all editables instead
+    chrome.contextMenus.create({
+      id: 'ruli-context-menu-test',
+      title: '히오스 공략툴 열기',
+      contexts: ['editable'],
+      // Use the same patterns used for injecting content scripts
+      documentUrlPatterns:
+        chrome.runtime.getManifest().content_scripts[0].matches,
+    });
+  }
 
   // Load pre-packaged hero data
   updateDataFromUrl(chrome.runtime.getURL('data/hots.json'))


### PR DESCRIPTION
This seems to be caused by a behavior change in Chrome.

This reverts 1c2a04692eb6f9f2e2011961f9ee489f4af9618d and adds some comments.