### PR TITLE
More TypeScript fixes

### DIFF
--- a/api/tests/test-models.js
+++ b/api/tests/test-models.js
@@ -11,9 +11,14 @@ import { fileURLToPath } from "url";
 
 import { HotsData } from "../src/hots-data.js";
 
+/**
+ * @typedef {import("../../generated-types/hots").Hero} StaticHero
+ */
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe("Hero", () => {
+  /** @type {Object<string, StaticHero>} */
   let heroJsonCompact;
   /** @type {{ [heroId: string]: import("../src/hero").Hero }} */
   let heroes;

--- a/chrome-ext/src/js/components/dialog-content.js
+++ b/chrome-ext/src/js/components/dialog-content.js
@@ -1,10 +1,12 @@
 /** @file Component representing the dialog content. */
 
 /**
- * @typedef {import('../../../../api/src/hero').Hero} Hero
- * @typedef {import('../../../../api/src/hots-data').HotsData} HotsData
  * @typedef {import('../hots-dialog-paster').HtmlPaster} HtmlPaster
  * @typedef {import('../hots-dialog-renderer').Renderer} Renderer
+ * @typedef {import("../decorate-hots-data.js").DecoratedHero} DecoratedHero
+ * @typedef {import("../decorate-hots-data.js").DecoratedHotsData} DecoratedHotsData
+ * @typedef {import("../decorate-hots-data.js").DecoratedSkill} DecoratedSkill
+ * @typedef {import("../decorate-hots-data.js").DecoratedTalent} DecoratedTalent
  * @typedef {import("../hots-dialog.js").ActiveFilters} ActiveFilters
  * @typedef {import("../hots-dialog.js").HeroFilterPresets} HeroFilterPresets
  * @typedef {import("../hots-dialog.js").HeroFilterType} HeroFilterType
@@ -22,7 +24,7 @@ const html = htm.bind(createElement);
 
 /**
  * @typedef {object} Props
- * @property {HotsData} data HotS data object
+ * @property {DecoratedHotsData} data HotS data object
  * @property {HeroFilterPresets} heroFilters Mapping of hero filter IDs
  *    to hero filters
  * @property {Renderer} renderer Renderer for generating HotsBoxes
@@ -32,7 +34,7 @@ const html = htm.bind(createElement);
 /**
  * @typedef {object} State
  * @property {ActiveFilters} activeFilters
- * @property {Hero | null} currentHero
+ * @property {DecoratedHero | null} currentHero
  * @property {boolean} shouldAddHotsVersion
  * @property {boolean} shouldUsePtr
  * @property {boolean} shouldUseSimpleHeroBox
@@ -119,13 +121,13 @@ export class DialogContent extends Component {
     let version = "";
     if (shouldAddHotsVersion) {
       const { data } = this.props;
-      version = shouldUsePtr ? data.hotsPtrVersion : data.hotsVersion;
+      version = (shouldUsePtr ? data.hotsPtrVersion : data.hotsVersion) || "";
     }
     return { iconSize, version };
   }
 
   /**
-   * @param {Hero} hero
+   * @param {DecoratedHero} hero
    * @return {Element[]}
    */
   pasteHero(hero) {
@@ -142,7 +144,7 @@ export class DialogContent extends Component {
   }
 
   /**
-   * @param {Skill} skill
+   * @param {DecoratedSkill} skill
    * @return {Element[]}
    */
   pasteSkill(skill) {
@@ -153,7 +155,7 @@ export class DialogContent extends Component {
   }
 
   /**
-   * @param {Talent} talent
+   * @param {DecoratedTalent} talent
    * @return {Element[]}
    */
   pasteTalent(talent) {
@@ -164,7 +166,7 @@ export class DialogContent extends Component {
   }
 
   /**
-   * @param {Talent[]} talentGroup
+   * @param {DecoratedTalent[]} talentGroup
    * @return {Element[]}
    */
   pasteTalentGroup(talentGroup) {

--- a/chrome-ext/src/js/components/hero-menu.js
+++ b/chrome-ext/src/js/components/hero-menu.js
@@ -1,35 +1,32 @@
 /** @file Component for a menu of clickable hero icons. */
 
-/**
- * @typedef {import("../../../../api/src/hero").Hero} Hero
- */
-
 import htm from "../vendor/htm.js";
 import { createElement } from "../vendor/preact.js";
 
 const html = htm.bind(createElement);
 
 /**
- * @typedef {import("../hots-dialog.js").HeroFilterType} HeroFilterType
+ * @typedef {import("../decorate-hots-data.js").DecoratedHero} DecoratedHero
  * @typedef {import("../hots-dialog.js").ActiveFilters} ActiveFilters
+ * @typedef {import("../hots-dialog.js").HeroFilterType} HeroFilterType
  */
 
 /**
- * @typedef {{ [K in HeroFilterType]: Set<Hero[K]> }} ActiveFilterSets
+ * @typedef {{ [K in HeroFilterType]: Set<DecoratedHero[K]> }} ActiveFilterSets
  */
 
 /**
  * @typedef {object} Props
- * @property {Object<string, Hero>} heroes Mapping of hero IDs to Hero objects
- *    for live server data
- * @property {Object<string, Hero>} ptrHeroes Mapping of hero IDs to Hero
- *    objects for PTR server data
+ * @property {Object<string, DecoratedHero>} heroes Mapping of hero IDs to
+ *    DecoratedHero objects for live server data
+ * @property {Object<string, DecoratedHero>} ptrHeroes Mapping of hero IDs to
+ *    DecoratedHero objects for PTR server data
  * @property {ActiveFilters} activeFilters Maps filter types to arrays of active
  *    filter IDs
  * @property {boolean} ptrMode If truthy, only heroes added or changed in PTR
  *    are highlighted, and their PTR data is passed to `onClickHero`.
- * @property {(hero: Hero) => void} props.onClickHero Called when the user
- *    clicks on a hero. Argument is the clicked Hero object.
+ * @property {(hero: DecoratedHero) => void} props.onClickHero Called when the
+ *    user clicks on a hero. Argument is the clicked DecoratedHero object.
  */
 
 /**
@@ -102,7 +99,7 @@ export function HeroMenu(props) {
 
 /**
  * Tests a hero against a set of active filters.
- * @param {Hero} hero Hero object to test
+ * @param {DecoratedHero} hero Hero object to test
  * @param {ActiveFilterSets} activeFilters
  * @return {boolean}
  */
@@ -112,7 +109,19 @@ function canHeroPassFilters(hero, activeFilters) {
     if (!filterSet.size) continue; // Skip filterSet if empty
 
     const heroAttribute = hero[filterType];
-    if (!filterSet.has(heroAttribute)) return false;
+    // Helper function needed to make TypeScript happy
+    if (!isInSet(heroAttribute, filterSet)) return false;
   }
   return true;
+}
+
+/**
+ * Helper function. Checks if `value` is in `set`.
+ * @template T
+ * @param {T} value
+ * @param {Set<T>} set
+ * @return {boolean}
+ */
+function isInSet(value, set) {
+  return set.has(value);
 }

--- a/chrome-ext/src/js/components/hots-box-menu.js
+++ b/chrome-ext/src/js/components/hots-box-menu.js
@@ -4,29 +4,29 @@ import { animateFlyingBox, getOffsetToViewport } from "../hots-dialog-util.js";
 import htm from "../vendor/htm.js";
 import { Fragment, createElement } from "../vendor/preact.js";
 
-/**
- * @typedef {import("../../../../api/src/hero").Hero} Hero
- * @typedef {import("../../../../api/src/skill").Skill} Skill
- * @typedef {import("../../../../api/src/talent").Talent} Talent
- * @typedef {import('../hots-dialog-renderer').Renderer} Renderer
- */
-
 const html = htm.bind(createElement);
 
 /**
+ * @typedef {import("../decorate-hots-data.js").DecoratedHero} DecoratedHero
+ * @typedef {import("../decorate-hots-data.js").DecoratedSkill} DecoratedSkill
+ * @typedef {import("../decorate-hots-data.js").DecoratedTalent} DecoratedTalent
+ * @typedef {import("../hots-dialog-renderer.js").Renderer} Renderer
+ */
+
+/**
  * @typedef {object} Props
- * @property {?Hero} hero Currently selected Hero object
- * @property {(hero: Hero) => Element[]} onPasteHero Called when the user clicks
- *    on a hero. Argument is the clicked Hero object.
+ * @property {?DecoratedHero} hero Currently selected DecoratedHero object
+ * @property {(hero: DecoratedHero) => Element[]} onPasteHero Called when the
+ *    user clicks on a hero.
  *    Must return an array of pasted elements.
- * @property {(skill: Skill) => Element[]} onPasteSkill Called when the user
- *    clicks on a skill. Argument is the clicked Skill object.
+ * @property {(skill: DecoratedSkill) => Element[]} onPasteSkill Called when the
+ *    user clicks on a skill.
  *    Must return an array of pasted elements.
- * @property {(talent: Talent) => Element[]} onPasteTalent Called when the user
- *    clicks on a talent. Argument is the clicked Talent object.
+ * @property {(talent: DecoratedTalent) => Element[]} onPasteTalent Called when
+ *    the user clicks on a talent.
  *    Must return an array of pasted elements.
- * @property {(talents: Talent[]) => Element[]} onPasteTalentGroup Called when
- *    the user clicks on a talent group. Argument is array of Talent objects.
+ * @property {(talents: DecoratedTalent[]) => Element[]} onPasteTalentGroup
+ *    Called when the user clicks on a talent group.
  *    Must return an array of pasted elements.
  */
 
@@ -40,7 +40,7 @@ export function HotsBoxMenu(props) {
   if (!hero) return /** @type {preact.VNode<Props>} */ (html`<${Fragment} />`);
 
   /**
-   * @param {Hero} hero
+   * @param {DecoratedHero} hero
    * @param {Event} event
    */
   function pasteHeroWithEffect(hero, event) {
@@ -49,7 +49,7 @@ export function HotsBoxMenu(props) {
   }
 
   /**
-   * @param {Skill} skill
+   * @param {DecoratedSkill} skill
    * @param {Event} event
    */
   function pasteSkillWithEffect(skill, event) {
@@ -58,7 +58,7 @@ export function HotsBoxMenu(props) {
   }
 
   /**
-   * @param {Talent} talent
+   * @param {DecoratedTalent} talent
    * @param {Event} event
    */
   function pasteTalentWithEffect(talent, event) {
@@ -67,7 +67,7 @@ export function HotsBoxMenu(props) {
   }
 
   /**
-   * @param {Talent[]} talentGroup
+   * @param {DecoratedTalent[]} talentGroup
    * @param {Event} event
    */
   function pasteTalentGroupWithEffect(talentGroup, event) {

--- a/chrome-ext/src/js/hots-dialog-dialog.js
+++ b/chrome-ext/src/js/hots-dialog-dialog.js
@@ -11,15 +11,15 @@ import { getSelectedChildWindow } from "./hots-dialog-util.js";
 import htm from "./vendor/htm.js";
 import { createElement, render } from "./vendor/preact.js";
 
-/**
- * @typedef {{name: string, filters: Object<string, string>}} HeroFilter
- * @typedef {import('../../../api/src/hots-data').HotsData} HotsData
- */
-
 const html = htm.bind(createElement);
 
 /**
+ * @typedef {import("./decorate-hots-data.js").DecoratedHotsData} DecoratedHotsData
  * @typedef {import("./hots-dialog.js").HeroFilterPresets} HeroFilterPresets
+ */
+
+/**
+ * @typedef {{name: string, filters: Object<string, string>}} HeroFilter
  */
 
 /** Represents a Dialog for selecting and pasting HotS Boxes. */
@@ -27,7 +27,7 @@ export class Dialog {
   /**
    * Creates a new Dialog instance.
    * @param {Object<string, string>} templates Rendering templates
-   * @param {HotsData} data HotS data
+   * @param {DecoratedHotsData} data
    * @param {HeroFilterPresets} heroFilters Mapping of hero filter IDs to hero
    *    filters
    */

--- a/chrome-ext/src/js/hots-dialog-renderer.js
+++ b/chrome-ext/src/js/hots-dialog-renderer.js
@@ -2,18 +2,18 @@
  * @file Provides renderer functions that convert HotS data objects to HTML.
  */
 
-/**
- * @typedef {import("../../../api/src/hero").Hero} Hero
- * @typedef {import("../../../api/src/skill").Skill} Skill
- * @typedef {import("../../../api/src/talent").Talent} Talent
- */
-
 import Mustache from "./vendor/mustache.js";
+
+/**
+ * @typedef {import("./decorate-hots-data.js").DecoratedHero} DecoratedHero
+ * @typedef {import("./decorate-hots-data.js").DecoratedSkill} DecoratedSkill
+ * @typedef {import("./decorate-hots-data.js").DecoratedTalent} DecoratedTalent
+ */
 
 /**
  * @typedef {object} SkillGroup
  * @property {string} title
- * @property {Skill[]} skills
+ * @property {DecoratedSkill[]} skills
  */
 
 /**
@@ -42,8 +42,8 @@ import Mustache from "./vendor/mustache.js";
  */
 
 /**
- * @typedef {Hero & _HeroView} HeroView
- * @typedef {Skill & _SkillView} SkillView
+ * @typedef {DecoratedHero & _HeroView} HeroView
+ * @typedef {DecoratedSkill & _SkillView} SkillView
  */
 
 /** Template-based renderer that generates HTML strings. */
@@ -58,7 +58,7 @@ export class Renderer {
 
   /**
    * Generates a table of hero information to be injected into a page.
-   * @param {Hero} hero Hero data
+   * @param {DecoratedHero} hero Hero data
    * @param {number=} iconSize Hero icon size in pixels (default: 64)
    * @param {number=} skillIconSize Skill i size in pixels (default: 48)
    * @param {string=} hotsVersion (optional) HotS version string to display
@@ -127,7 +127,7 @@ export class Renderer {
 
   /**
    * Generates a table of skill information to be injected into a page.
-   * @param {Skill} skill Skill data
+   * @param {DecoratedSkill} skill Skill data
    * @param {number=} iconSize Icon size in pixels (default: 64)
    * @param {string=} hotsVersion (optional) HotS version string to display
    * @return {string} HTML source
@@ -142,7 +142,7 @@ export class Renderer {
 
   /**
    * Generates a table of talent information to be injected into a page.
-   * @param {Talent} talent Talent data
+   * @param {DecoratedTalent} talent Talent data
    * @param {number=} iconSize Icon size in pixels (default: 48)
    * @param {string=} hotsVersion (optional) HotS version string to display
    * @return {string} HTML source
@@ -162,7 +162,7 @@ export class Renderer {
 
   /**
    * Generates a row of talent tables from a talent group.
-   * @param {Talent[]} talentGroup Talent group
+   * @param {DecoratedTalent[]} talentGroup Talent group
    * @param {number=} iconSize Icon size in pixels (default: 48)
    * @param {string=} hotsVersion (optional) HotS version string to display
    * @return {string} HTML source
@@ -179,7 +179,7 @@ export class Renderer {
    * Generates a Mustache-compatible view from a Skill or Talent.
    * This is an internal method called by other generator methods.
    * @package
-   * @param {Skill | Talent} skill Skill or Talent object
+   * @param {DecoratedSkill | DecoratedTalent} skill Skill or Talent object
    * @param {number=} iconSize Icon size in pixels (default: 48)
    * @param {string=} hotsVersion (optional) HotS version string
    * @return {SkillView} Object to be fed into Mustache

--- a/chrome-ext/tests/test-renderers.js
+++ b/chrome-ext/tests/test-renderers.js
@@ -15,18 +15,24 @@ import { Renderer } from "../src/js/hots-dialog-renderer.js";
 
 import { loadTemplates } from "./js/mocks.js";
 
+/**
+ * @typedef {import("../src/js/decorate-hots-data.js").DecoratedHotsData} DecoratedHotsData
+ */
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe("HotsDialog.Renderer", () => {
+  /** @type {DecoratedHotsData} */
   let hotsData;
   /** @type {Renderer} */
   let renderer;
 
   before("Loading test data files", async () => {
-    hotsData = JSON.parse(
-      fs.readFileSync(path.join(__dirname, "data/hots.json"), "utf8")
+    hotsData = decorateHotsData(
+      JSON.parse(
+        fs.readFileSync(path.join(__dirname, "data/hots.json"), "utf8")
+      )
     );
-    decorateHotsData(hotsData);
 
     const templates = await loadTemplates();
     renderer = new Renderer(templates);


### PR DESCRIPTION
Use the generated type definitions to properly type decorated data structures (generated by `decorate-hots-data.js`), then use those decorated types to properly type the rest of the Chrome extension code under `/chrome-ext/`.

Nearly all of the typing errors have been fixed. The only remaining errors are in `merge-hdp.js`, which is broken because we don't have proper types for JSON files generated by HeroesDataParser.