### PR TITLE
Remove workaround for bug in @types/tingle.js

### DIFF
--- a/chrome-ext/src/js/hots-dialog-dialog.js
+++ b/chrome-ext/src/js/hots-dialog-dialog.js
@@ -63,8 +63,6 @@ export class Dialog {
       html`<${DialogContent} ...${dialogContentProps} />`,
       contentFragment
     );
-    // TODO: Remove this when @types/tingle.js is updated
-    // @ts-expect-error Parameter type of setContent() is too narrow
     this._dialog.setContent(contentFragment);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,9 +131,9 @@
       "dev": true
     },
     "@types/tingle.js": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@types/tingle.js/-/tingle.js-0.13.0.tgz",
-      "integrity": "sha512-7a8eTFQbSsR4A87lTiScPmja6wt6wYwJEfyhidQ+INRlZQZvY17mvR/a6QgD7qsw5Yyc184P9g5Vn2wZVYhUYw==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@types/tingle.js/-/tingle.js-0.13.1.tgz",
+      "integrity": "sha512-Ke2Aza6HGg1v3dessXdNogGhyHNzTeYKDNLzGks7L0WnO4bPtIjuhIw2+23FR+IFWNzehTgeeDYbfhslU9Izhg==",
       "dev": true
     },
     "@types/yazl": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/mocha": "^8.0.0",
     "@types/mustache": "^4.0.1",
     "@types/prettier": "^2.0.2",
-    "@types/tingle.js": "^0.13.0",
+    "@types/tingle.js": "^0.13.1",
     "@types/yazl": "^2.4.2",
     "commander": "^6.0.0",
     "eslint": "^7.6.0",


### PR DESCRIPTION
There was a small flaw in `@types/tingle.js` that forced me to use `// @ts-expect-error`.
Now that the bug is fixed in `@types/tingle.js` 0.13.1, I can safely remove it.
