### PR TITLE
Add Preact component tests

### DIFF
--- a/chrome-ext/tests/hero-menu.test.js
+++ b/chrome-ext/tests/hero-menu.test.js
@@ -1,0 +1,313 @@
+/**
+ * @file Tests for the HeroMenu component.
+ */
+
+import TLP from "@testing-library/preact";
+import htm from "htm";
+import jsdomGlobal from "jsdom-global";
+import { h } from "preact";
+import should from "should";
+import sinon from "sinon";
+
+import { _c } from "../../scripts/type-util.js";
+import { HeroMenu } from "../src/js/components/hero-menu.js";
+
+import { shouldNotEqual } from "./js/helpers.js";
+
+/**
+ * @typedef {import("../src/js/components/hero-menu.js").Props} Props
+ */
+
+const { fireEvent, render } = TLP;
+const html = htm.bind(h);
+
+before(
+  /**
+   * @this Mocha.Context
+   * @param {Mocha.Done} done
+   */
+  function (done) {
+    this.timeout(0); // Disable Mocha's timeout
+
+    this.cleanup = jsdomGlobal(
+      `
+      <html>
+        <head>
+          <link rel="stylesheet" href="../src/css/ruliweb-hots.css">
+        </head>
+      </html>
+      `,
+      {
+        resources: "usable",
+        url: import.meta.url,
+      }
+    );
+
+    // Wait for JSDOM to load external stylesheet
+    window.onload = () => {
+      done();
+    };
+  }
+);
+
+after(
+  /** @this Mocha.Context */ function () {
+    this.cleanup();
+  }
+);
+
+describe("HeroMenu", () => {
+  const heroes = {
+    /** @type {Props["heroes"][string]} */
+    Romeo: {
+      name: "Romeo Montague",
+      title: "Man in love",
+      icon: "icon_romeo",
+      newRole: _c("melee_assassin"),
+      universe: _c("nexus"),
+      stats: [],
+      id: "Romeo",
+      iconUrl: "https://example.com/romeo.png",
+      roleName: "근접 암살자",
+      universeName: "시공의 폭풍",
+      units: [],
+      skills: [],
+      talents: {},
+    },
+    /** @type {Props["heroes"][string]} */
+    Juliet: {
+      name: "Juliet Capulet",
+      title: "Woman in love",
+      icon: "icon_juliet",
+      newRole: _c("tank"),
+      universe: _c("starcraft"),
+      stats: [],
+      id: "Juliet",
+      iconUrl: "https://example.com/juliet.png",
+      roleName: "전사",
+      universeName: "스타크래프트",
+      units: [],
+      skills: [],
+      talents: {},
+    },
+  };
+
+  const ptrHeroes = {
+    // Hero added in PTR
+    /** @type {Props["ptrHeroes"][string]} */
+    Hamlet: {
+      name: "Hamlet of Denmark",
+      title: "Mad prince",
+      icon: "icon_hamlet",
+      newRole: _c("bruiser"),
+      universe: _c("diablo"),
+      stats: [],
+      id: "Hamlet",
+      iconUrl: "https://example.com/hamlet.png",
+      roleName: "투사",
+      universeName: "디아블로",
+      units: [],
+      skills: [],
+      talents: {},
+    },
+    // Hero changed in PTR
+    /** @type {Props["ptrHeroes"][string]} */
+    Juliet: {
+      ...heroes.Juliet,
+      name: "Juliet Capulet, DEAD",
+      title: "Woman who committed suicide",
+      icon: "icon_juliet_death",
+      newRole: _c("ranged_assassin"),
+      universe: _c("overwatch"),
+      iconUrl: "https://example.com/juliet_dead.png",
+    },
+  };
+
+  it("should show icons, tooltips, and badges for each hero", () => {
+    /** @type {Props["activeFilters"]} */
+    const activeFilters = { newRole: [], universe: [] };
+
+    const { getAllByRole, getByLabelText, getByRole } = render(html`
+      <${HeroMenu}
+        heroes=${heroes}
+        ptrHeroes=${ptrHeroes}
+        activeFilters=${activeFilters}
+      />
+    `);
+
+    // TODO: Maybe I should use <input type="image"> instead of plain <img>
+    // so that I can utilize more proper ARIA roles, e.g. "button".
+    const romeoIcon = getByRole("img", { name: new RegExp(heroes.Romeo.name) });
+    const julietIcon = getByRole("img", {
+      name: new RegExp(heroes.Juliet.name),
+    });
+    const hamletIcon = getByRole("img", {
+      name: new RegExp(ptrHeroes.Hamlet.name),
+    });
+
+    romeoIcon.should.have.property("src", heroes.Romeo.iconUrl);
+    julietIcon.should.have.property("src", heroes.Juliet.iconUrl);
+    hamletIcon.should.have.property("src", ptrHeroes.Hamlet.iconUrl);
+
+    // Hero icons should be sorted by hero ID
+    getAllByRole("img").should.eql([hamletIcon, julietIcon, romeoIcon]);
+
+    // Check for existence and order of tooltips
+    const romeoTooltipEl = getByLabelText(new RegExp(heroes.Romeo.name));
+    const julietTooltipEl = getByLabelText(new RegExp(heroes.Juliet.name));
+    const hamletTooltipEl = getByLabelText(new RegExp(ptrHeroes.Hamlet.name));
+
+    getAllByRole("tooltip").should.eql([
+      julietTooltipEl,
+      romeoTooltipEl,
+      hamletTooltipEl,
+    ]);
+
+    // Check tooltip text: hero name, role, PTR added/changed status
+
+    // Romeo is a hero on live with no changes in PTR
+    const romeoTooltip = romeoTooltipEl.getAttribute("aria-label");
+    should(romeoTooltip).containEql(heroes.Romeo.roleName);
+    should(romeoTooltip).not.containEql("PTR");
+    should(romeoTooltip).not.containEql("변경");
+
+    // Juliet is existing hero with changes in PTR
+    const julietTooltip = julietTooltipEl.getAttribute("aria-label");
+    should(julietTooltip).containEql(heroes.Juliet.roleName);
+    should(julietTooltip).containEql("PTR");
+    should(julietTooltip).containEql("변경");
+
+    // Hamlet is new hero in PTR
+    const hamletTooltip = hamletTooltipEl.getAttribute("aria-label");
+    should(hamletTooltip).containEql(ptrHeroes.Hamlet.roleName);
+    should(hamletTooltip).containEql("PTR");
+    should(hamletTooltip).containEql("추가");
+
+    // Check badges
+
+    // Romeo is a hero on live with no changes in PTR
+    const romeoRoot = romeoIcon.parentElement;
+    shouldNotEqual(romeoRoot, null);
+    should.not.exist(TLP.queryByText(romeoRoot, "PTR"));
+    should.not.exist(TLP.queryByText(romeoRoot, "NEW"));
+
+    // Juliet is existing hero with changes in PTR
+    const julietRoot = julietIcon.parentElement;
+    shouldNotEqual(julietRoot, null);
+    TLP.getByText(julietRoot, "PTR");
+    should.not.exist(TLP.queryByText(julietRoot, "NEW"));
+
+    // Hamlet is new hero in PTR
+    const hamletRoot = hamletIcon.parentElement;
+    shouldNotEqual(hamletRoot, null);
+    TLP.queryByText(hamletRoot, "NEW");
+    should.not.exist(TLP.queryByText(hamletRoot, "PTR"));
+
+    // Check highlighting: If no filter is set, all heroes should be highlighted
+    getAllByRole("img")
+      .map((img) => Number(getComputedStyle(img).opacity))
+      .should.eql([0, 0, 0]);
+  });
+
+  it("should highlight heroes that pass the filters", () => {
+    /** @type {Props["activeFilters"]} */
+    const activeFilters = {
+      newRole: ["tank", "bruiser"],
+      universe: ["starcraft"],
+    };
+
+    const { getByRole } = render(html`
+      <${HeroMenu}
+        heroes=${heroes}
+        ptrHeroes=${ptrHeroes}
+        activeFilters=${activeFilters}
+      />
+    `);
+
+    // Romeo: "melee_assassin", "nexus" -> not highlighted
+    const romeoIcon = getByRole("img", { name: new RegExp(heroes.Romeo.name) });
+    Number(getComputedStyle(romeoIcon).opacity).should.be.above(0);
+
+    // Juliet: "tank", "starcraft" -> highlighted
+    const julietIcon = getByRole("img", {
+      name: new RegExp(heroes.Juliet.name),
+    });
+    Number(getComputedStyle(julietIcon).opacity).should.equal(0);
+
+    // Hamlet: "bruiser", "diablo" -> not highlighted (dark)
+    const hamletIcon = getByRole("img", {
+      name: new RegExp(ptrHeroes.Hamlet.name),
+    });
+    Number(getComputedStyle(hamletIcon).opacity).should.be.above(0);
+  });
+
+  describe("onClickHero() callback", () => {
+    it("should be passed a live hero if ptrMode is falsy", () => {
+      /** @type {Props["activeFilters"]} */
+      const activeFilters = {
+        newRole: ["tank", "bruiser"],
+        universe: ["starcraft"],
+      };
+
+      const clickHeroHandler = sinon.spy();
+
+      const { getByRole } = render(html`
+        <${HeroMenu}
+          heroes=${heroes}
+          ptrHeroes=${ptrHeroes}
+          activeFilters=${activeFilters}
+          onClickHero=${clickHeroHandler}
+        />
+      `);
+
+      clickHeroHandler.should.not.be.called();
+
+      fireEvent.click(
+        getByRole("img", { name: new RegExp(heroes.Romeo.name) })
+      );
+      clickHeroHandler.should.be.calledOnce();
+      clickHeroHandler.firstCall.args.should.have.length(1);
+      clickHeroHandler.firstCall.args[0].should.be.equal(heroes.Romeo);
+
+      fireEvent.click(
+        getByRole("img", { name: new RegExp(heroes.Juliet.name) })
+      );
+      clickHeroHandler.should.be.calledTwice();
+      clickHeroHandler.secondCall.args.should.have.length(1);
+      clickHeroHandler.secondCall.args[0].should.be.equal(heroes.Juliet);
+
+      fireEvent.click(
+        getByRole("img", { name: new RegExp(ptrHeroes.Hamlet.name) })
+      );
+      clickHeroHandler.should.be.calledThrice();
+      clickHeroHandler.thirdCall.args.should.have.length(1);
+      clickHeroHandler.thirdCall.args[0].should.be.equal(ptrHeroes.Hamlet);
+    });
+
+    it("should be passed a PTR hero if ptrMode is truthy", () => {
+      /** @type {Props["activeFilters"]} */
+      const activeFilters = { newRole: [], universe: [] };
+
+      const clickHeroHandler = sinon.spy();
+
+      const { getByRole } = render(html`
+        <${HeroMenu}
+          heroes=${heroes}
+          ptrHeroes=${ptrHeroes}
+          activeFilters=${activeFilters}
+          onClickHero=${clickHeroHandler}
+          ptrMode=${true}
+        />
+      `);
+
+      clickHeroHandler.should.not.be.called();
+
+      fireEvent.click(
+        getByRole("img", { name: new RegExp(ptrHeroes.Juliet.name) })
+      );
+      clickHeroHandler.should.be.calledOnce();
+      clickHeroHandler.firstCall.args.should.have.length(1);
+      clickHeroHandler.firstCall.args[0].should.be.equal(ptrHeroes.Juliet);
+    });
+  });
+});

--- a/chrome-ext/tests/hots-box-menu.test.js
+++ b/chrome-ext/tests/hots-box-menu.test.js
@@ -1,0 +1,323 @@
+/**
+ * @file Tests for the HotsBoxMenu component.
+ */
+
+import TLP from "@testing-library/preact";
+import htm from "htm";
+import jsdomGlobal from "jsdom-global";
+import { h } from "preact";
+import should from "should";
+import "should-sinon";
+import sinon from "sinon";
+
+import { HotsBoxMenu } from "../src/js/components/hots-box-menu.js";
+
+import { shouldNotEqual } from "./js/helpers.js";
+
+/**
+ * @typedef {import("../src/js/components/hots-box-menu.js").Props} Props
+ */
+
+const { fireEvent, render } = TLP;
+const html = htm.bind(h);
+
+before(
+  /**
+   * @this Mocha.Context
+   * @param {Mocha.Done} done
+   */
+  function (done) {
+    this.timeout(0); // Disable Mocha's timeout
+
+    this.cleanup = jsdomGlobal(
+      `
+      <html>
+        <head>
+          <link rel="stylesheet" href="../src/css/ruliweb-hots.css">
+        </head>
+      </html>
+      `,
+      {
+        resources: "usable",
+        url: import.meta.url,
+      }
+    );
+
+    // Wait for JSDOM to load external stylesheet
+    window.onload = () => {
+      done();
+    };
+  }
+);
+
+after(
+  /** @this Mocha.Context */ function () {
+    this.cleanup();
+  }
+);
+
+describe("HotsBoxMenu", () => {
+  // NOTE: Hero, skill, and icon names used in this test should not contain
+  // special characters recognized by RegExp(). This is not a requirement of the
+  // component, but a consequence of using RegExp() to loosely match DOM nodes
+  // using DOM Testing Library's query functions.
+  /** @type {Props["hero"]} */
+  const hero = {
+    id: "JayGatsbyHeroId",
+    name: "Jay Gatsby",
+    icon: "hero_icon_gatsby",
+    iconUrl: "https://example.com/hero/jay-gatsby.png",
+    title: "Rejected Millionaire",
+    newRole: "support",
+    roleName: "지원가",
+    universe: "warcraft",
+    universeName: "워크래프트",
+    stats: [],
+    units: [],
+    skills: [],
+    talents: {},
+  };
+  hero.skills = [
+    {
+      index: 0,
+      id: "SkillHoldPartyId",
+      name: "Hold Extravagant Party",
+      icon: "skill_icon_hold_party",
+      iconUrl: "https://example.com/skill/hold-party.png",
+      type: "Q",
+      typeName: "Q",
+      typeNameLong: "Q",
+      description:
+        "Hold an over-the-top lavish party, attracting men and girls like moths to a bright light.\n\nPassive: You are rich.",
+      tooltipDescription:
+        "Hold an over-the-top lavish party, attracting men and girls like moths to a bright light.\n\nPassive: You are rich.",
+      shortDescription: "Hold a really fancy party",
+      manaCost: 100,
+      rechargeCooldown: 24 * 60 * 60,
+      heroId: hero.id,
+      heroName: hero.name,
+    },
+    {
+      index: 1,
+      id: "SkillDriveId",
+      name: "Drive Vehicle",
+      icon: "skill_icon_drive",
+      iconUrl: "https://example.com/skill/drive.png",
+      type: "E",
+      typeName: "E",
+      typeNameLong: "E",
+      description:
+        "Basic driving skills.\n\nDo NOT swap seats with your lover!",
+      tooltipDescription:
+        "Basic driving skills.<br><br>Do NOT swap seats with your lover!",
+      shortDescription: "Driving a car",
+      heroId: hero.id,
+      heroName: hero.name,
+    },
+  ];
+  hero.talents["4"] = [
+    {
+      level: 4,
+      index: 0,
+      id: "TalentAskNeighborForInvitationId",
+      name: "Ask Neighbor to Invite You",
+      icon: "talent_ask_neighbor",
+      iconUrl: "https://example.com/talent/ask-neighbor.png",
+      type: "active",
+      manaCost: 250,
+      cooldown: 1250,
+      upgradeFor: "W",
+      typeName: "W",
+      typeNameLong: "능력 강화 (W)",
+      description:
+        "Believe in your unattainable ideals, unlike the rest of the rabble who are busy breaking things carelessly or chasing after wealth.",
+      tooltipDescription:
+        "Believe in your unattainable ideals, unlike the rest of the rabble who are busy breaking things carelessly or chasing after wealth.",
+      shortDescription: "Believe in the green light across the dock",
+      heroId: hero.id,
+      heroName: hero.name,
+    },
+    {
+      level: 4,
+      index: 0,
+      id: "TalentReunionId",
+      name: "The Reunion",
+      icon: "talent_reunion",
+      iconUrl: "https://example.com/talent/the-reunion.png",
+      type: "passive",
+      typeName: "지속 효과",
+      typeNameLong: "지속 효과",
+      description: "Reunite with your former lover. Happy end?",
+      tooltipDescription: "Reunite with your former lover. Happy end?",
+      shortDescription: "Reunite with former lover",
+      heroId: hero.id,
+      heroName: hero.name,
+    },
+  ];
+  hero.talents["11"] = [
+    {
+      level: 11,
+      index: 0,
+      id: "TalentBelieveInGreenLightId",
+      name: "Believe in the Green Light",
+      icon: "talent_believe_green_light",
+      iconUrl: "https://example.com/talent/green-light.png",
+      type: "passive",
+      upgradeFor: "Q",
+      typeName: "Q",
+      typeNameLong: "능력 강화 (Q)",
+      description:
+        "Believe in your unattainable ideals, unlike the rest of the rabble who are busy breaking things carelessly or chasing after wealth.",
+      tooltipDescription:
+        "Believe in your unattainable ideals, unlike the rest of the rabble who are busy breaking things carelessly or chasing after wealth.",
+      shortDescription: "Believe in the green light across the dock",
+      heroId: hero.id,
+      heroName: hero.name,
+    },
+  ];
+
+  it("should show nothing if no hero is given", () => {
+    const { queryAllByRole } = render(html`<${HotsBoxMenu} hero=${null} />`);
+
+    queryAllByRole("img").should.be.empty();
+    queryAllByRole("tooltip").should.be.empty();
+  });
+
+  it("should show icons with tooltips for the hero, skills, and talents", () => {
+    const { getAllByRole, getByRole } = render(
+      html`<${HotsBoxMenu} hero=${hero} />`
+    );
+
+    // Check for existence of hero icon
+    const heroIcon = getByRole("img", { name: new RegExp(hero.name) });
+    heroIcon.should.have.property("src", hero.iconUrl);
+
+    // Check hero icon tooltip
+    const heroIconTooltipEl = getByRole("tooltip", {
+      name: new RegExp(hero.name),
+    });
+    shouldNotEqual(heroIconTooltipEl, null);
+    const heroIconTooltip = heroIconTooltipEl.getAttribute("aria-label");
+    should(heroIconTooltip).containEql(hero.name);
+    should(heroIconTooltip).containEql(hero.roleName);
+
+    // Check skills
+    for (const skill of hero.skills) {
+      // Check for existence of icon
+      const skillIcon = getByRole("img", { name: new RegExp(skill.name) });
+      skillIcon.should.have.property("src", skill.iconUrl);
+
+      // Check tooltip
+      const skillIconTooltipEl = getByRole("tooltip", {
+        name: new RegExp(skill.name),
+      });
+      const skillIconTooltip = skillIconTooltipEl.getAttribute("aria-label");
+      should(skillIconTooltip).containEql(skill.typeName);
+      should(skillIconTooltip).containEql(skill.tooltipDescription);
+    }
+
+    // Check talents
+    for (const [tierName, tierArray] of Object.entries(hero.talents)) {
+      for (const talent of tierArray) {
+        // Check for existence of icon
+        const talentIcon = getByRole("img", { name: new RegExp(talent.name) });
+        talentIcon.should.have.property("src", talent.iconUrl);
+
+        const talentIconRoot = talentIcon.parentElement;
+        shouldNotEqual(talentIconRoot, null);
+        const talentIconTooltip = talentIconRoot.getAttribute("aria-label");
+        should(talentIconTooltip).containEql(talent.name);
+        should(talentIconTooltip).containEql(talent.typeNameLong);
+        should(talentIconTooltip).containEql(`레벨 ${tierName}`);
+        should(talentIconTooltip).containEql(talent.tooltipDescription);
+      }
+    }
+
+    // Check talent group buttons
+    getAllByRole("button", { name: "모두 넣기" }).should.have.length(
+      Object.keys(hero.talents).length
+    );
+  });
+
+  it("should call callback if a hero/skill/talent icon, or talent group is clicked", () => {
+    // Currently, this component handles the post-paste animation effect.
+    // This is not ideal, because each callback is required to return an array.
+    // Instead, we could pass the clicked <img> element as the second argument
+    // to each handler, and let the handler run the animation effect.
+    // TODO: Move post-paste animation effect to <DialogContent>
+    const pasteHeroHandler = sinon.fake.returns([]);
+    const pasteSkillHandler = sinon.fake.returns([]);
+    const pasteTalentHandler = sinon.fake.returns([]);
+    const pasteTalentGroupHandler = sinon.fake.returns([]);
+
+    const { getAllByRole, getByRole } = render(html`
+      <${HotsBoxMenu}
+        hero=${hero}
+        onPasteHero=${pasteHeroHandler}
+        onPasteSkill=${pasteSkillHandler}
+        onPasteTalent=${pasteTalentHandler}
+        onPasteTalentGroup=${pasteTalentGroupHandler}
+      />
+    `);
+
+    // Test hero icon click
+    pasteHeroHandler.should.not.be.called();
+
+    fireEvent.click(getByRole("img", { name: new RegExp(hero.name) }));
+    pasteHeroHandler.should.be.calledOnce();
+    pasteHeroHandler.firstCall.args.should.have.length(1);
+    pasteHeroHandler.firstCall.args[0].should.equal(hero);
+
+    // Test skill icon click
+    const [skill0, skill1] = hero.skills;
+    pasteSkillHandler.should.not.be.called();
+
+    fireEvent.click(getByRole("img", { name: new RegExp(skill1.name) }));
+    pasteSkillHandler.should.be.calledOnce();
+    pasteSkillHandler.firstCall.args.should.have.length(1);
+    pasteSkillHandler.firstCall.args[0].should.equal(skill1);
+
+    fireEvent.click(getByRole("img", { name: new RegExp(skill0.name) }));
+    pasteSkillHandler.should.be.calledTwice();
+    pasteSkillHandler.secondCall.args.should.have.length(1);
+    pasteSkillHandler.secondCall.args[0].should.eql(skill0);
+
+    // Test talent icon click
+    const [talentA, talentB] = hero.talents["4"];
+    const [talentC] = hero.talents["11"];
+    pasteTalentHandler.should.not.be.called();
+
+    fireEvent.click(getByRole("img", { name: new RegExp(talentB.name) }));
+    pasteTalentHandler.should.be.calledOnce();
+    pasteTalentHandler.firstCall.args.should.have.length(1);
+    pasteTalentHandler.firstCall.args[0].should.equal(talentB);
+
+    fireEvent.click(getByRole("img", { name: new RegExp(talentA.name) }));
+    pasteTalentHandler.should.be.calledTwice();
+    pasteTalentHandler.secondCall.args.should.have.length(1);
+    pasteTalentHandler.secondCall.args[0].should.equal(talentA);
+
+    fireEvent.click(getByRole("img", { name: new RegExp(talentC.name) }));
+    pasteTalentHandler.should.be.calledThrice();
+    pasteTalentHandler.thirdCall.args.should.have.length(1);
+    pasteTalentHandler.thirdCall.args[0].should.equal(talentC);
+
+    // Test talent group buttons
+    const talentGroupButtons = getAllByRole("button", { name: "모두 넣기" });
+    pasteTalentGroupHandler.should.not.be.called();
+
+    fireEvent.click(talentGroupButtons[1]);
+    pasteTalentGroupHandler.should.be.calledOnce();
+    pasteTalentGroupHandler.firstCall.args.should.have.length(1);
+    pasteTalentGroupHandler.firstCall.args[0].should.be.equal(
+      hero.talents["11"]
+    );
+
+    fireEvent.click(talentGroupButtons[0]);
+    pasteTalentGroupHandler.should.be.calledTwice();
+    pasteTalentGroupHandler.secondCall.args.should.have.length(1);
+    pasteTalentGroupHandler.secondCall.args[0].should.be.equal(
+      hero.talents["4"]
+    );
+  });
+});

--- a/chrome-ext/tests/js/helpers.js
+++ b/chrome-ext/tests/js/helpers.js
@@ -1,0 +1,21 @@
+/**
+ * @file Helpers for tests
+ * Note: Having custom assertion functions outside the test scripts allows the
+ * IDE (VS Code + Mocha Test Explorer in my case) to correctly locate the source
+ * of the exception in a test script.
+ */
+
+import should from "should";
+
+// eslint-disable-next-line valid-jsdoc -- TypeScript syntax
+/**
+ * Assertion that also acts as a type guard.
+ * Asserts that `value !== expected`.
+ * @template T, U
+ * @param {T} value
+ * @param {U} expected
+ * @return {asserts value is Exclude<T, U>}
+ */
+export function shouldNotEqual(value, expected) {
+  should(value).not.equal(expected);
+}

--- a/chrome-ext/tests/js/mocks.js
+++ b/chrome-ext/tests/js/mocks.js
@@ -24,7 +24,7 @@ let readFileAsync;
 let templateJsonPath;
 
 // Execute this only in non-browser contexts (i.e. Node.js)
-if (typeof window === "undefined") {
+if (typeof global !== "undefined") {
   (async () => {
     try {
       const { readFile } = await import("fs");

--- a/chrome-ext/tests/multi-select-icons.test.js
+++ b/chrome-ext/tests/multi-select-icons.test.js
@@ -1,0 +1,139 @@
+/**
+ * @file Tests for the MultiSelectIcons component.
+ */
+
+import TLP from "@testing-library/preact";
+import htm from "htm";
+import jsdomGlobal from "jsdom-global";
+import { h } from "preact";
+import "should";
+import sinon from "sinon";
+
+import { MultiSelectIcons } from "../src/js/components/multi-select-icons.js";
+
+/**
+ * @template T
+ * @typedef {import("../src/js/components/multi-select-icons.js").Props<T>} Props
+ */
+
+const { fireEvent, render, waitFor } = TLP;
+const html = htm.bind(h);
+
+before(
+  /**
+   * @this Mocha.Context
+   * @param {Mocha.Done} done
+   */
+  function (done) {
+    this.timeout(0); // Disable Mocha's timeout
+
+    this.cleanup = jsdomGlobal(
+      `
+      <html>
+        <head>
+          <link rel="stylesheet" href="../src/css/ruliweb-hots.css">
+        </head>
+      </html>
+      `,
+      {
+        resources: "usable",
+        url: import.meta.url,
+      }
+    );
+
+    // Wait for JSDOM to load external stylesheet
+    window.onload = () => {
+      done();
+    };
+  }
+);
+
+after(
+  /** @this Mocha.Context */ function () {
+    this.cleanup();
+  }
+);
+
+describe("MultiSelectIcons", () => {
+  /**
+   * @typedef {"gilman" | "mansfield" | "chopin"} AuthorId
+   */
+
+  /** @type {Props<AuthorId>["options"]} */
+  const options = [
+    {
+      id: "gilman",
+      name: "Charlotte Perkins Gilman",
+      iconUrl: "https://example.com/author/charlotte-perkins-gilman.png",
+    },
+    {
+      id: "mansfield",
+      name: "Katherine Mansfield",
+      iconUrl: "https://example.com/author/katherine-mansfield.png",
+    },
+    {
+      id: "chopin",
+      name: "Kate Chopin",
+      iconUrl: "https://example.com/author/kate-chopin.png",
+    },
+  ];
+
+  it("should render checkboxes for each option", () => {
+    const { getByRole } = render(
+      html`<${MultiSelectIcons} options=${options} />`
+    );
+
+    // Currently, this query does not work because the checkboxes are hidden
+    // from assistive technologies with "display: none".
+    // TODO: Uncomment this when checkboxes become visible to assistive tech
+    // const checkboxes = getAllByRole("checkbox");
+    // checkboxes.should.have.length(options.length);
+
+    for (const option of options) {
+      const img = getByRole("img", { name: option.name });
+      img.should.have.property("src", option.iconUrl);
+    }
+
+    // TODO: Uncomment this when checkboxes become visible to assistive tech
+    // queryAllByRole("checkbox", { checked: true }).should.be.empty();
+    // queryAllByRole("checkbox", { checked: false }).should.have.length(
+    //   options.length
+    // );
+  });
+
+  it("should call onSelectChange() when checkboxes are clicked", async () => {
+    const selectChangeHandler = sinon.spy();
+
+    const { getByRole } = render(html`
+      <${MultiSelectIcons}
+        options=${options}
+        onSelectChange=${selectChangeHandler}
+      />
+    `);
+
+    selectChangeHandler.should.not.be.called();
+
+    // TODO: Change this to accessing checkbox by label
+    fireEvent.click(getByRole("img", { name: options[2].name }));
+    // The current implementation of <MultiSelectIcons> fires the callback
+    // *after* updating internal state, which is probably why we need await here.
+    // It also possibly makes the form less responsive. This is undesireable.
+    // To solve it, we should make <MultiSelectIcons> a *fully* controlled
+    // component; i.e. its checkbox states are driven entirely by props.
+    // TODO: Refactor <MultiSelectIcons>, then eliminate awaits
+    await waitFor(() => selectChangeHandler.should.be.calledOnce());
+    selectChangeHandler.firstCall.should.be.calledWithExactly([options[2].id]);
+
+    fireEvent.click(getByRole("img", { name: options[0].name }));
+    await waitFor(() => selectChangeHandler.should.be.calledTwice());
+    selectChangeHandler.secondCall.should.be.calledWithExactly([
+      options[0].id,
+      options[2].id,
+    ]);
+
+    // Turn off option 2
+    fireEvent.click(getByRole("img", { name: options[2].name }));
+    await waitFor(() => selectChangeHandler.should.be.calledThrice());
+    selectChangeHandler.thirdCall.should.be.calledWithExactly([options[0].id]);
+  });
+});

--- a/chrome-ext/tests/should-sinon.d.ts
+++ b/chrome-ext/tests/should-sinon.d.ts
@@ -1,0 +1,11 @@
+// Workaround for incorrect typing in @types/should-sinon
+// TODO: Remove this file when the following PR is merged:
+//    https://github.com/DefinitelyTyped/DefinitelyTyped/pull/47124
+
+import { ShouldSinonAssertion } from "should-sinon";
+
+declare module "sinon" {
+  interface SinonSpyCallApi {
+    should: ShouldSinonAssertion;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3111,6 +3111,11 @@
         "should-type-adaptors": "^1.0.1"
       }
     },
+    "should-sinon": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/should-sinon/-/should-sinon-0.0.6.tgz",
+      "integrity": "sha512-ScBOH5uW5QVFaONmUnIXANSR6z5B8IKzEmBP3HE5sPOCDuZ88oTMdUdnKoCVQdLcCIrRrhRLPS5YT+7H40a04g=="
+    },
     "should-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -304,6 +304,16 @@
       "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
       "dev": true
     },
+    "@types/should-sinon": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/should-sinon/-/should-sinon-0.0.6.tgz",
+      "integrity": "sha512-T8dDPaZEJ6t+lXjbUl4A1rPrgeM8WXuuRutv1XzMGNaS78ZRe4RdPY7If1xqmJbqo/7FFHsXeYdBCsQnJm5t+g==",
+      "dev": true,
+      "requires": {
+        "@types/sinon": "*",
+        "should": "^13.2.1"
+      }
+    },
     "@types/sinon": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,6 +215,15 @@
         "@types/tough-cookie": "*"
       }
     },
+    "@types/jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha512-CFIPEDpO5vQWdQrVXrdSR2j5giiDuyb0hzZD04OJqMfizt7sh6WoqaLBdnP4w74yHDDcQkc0k5TzrXffhua3Jg==",
+      "dev": true,
+      "requires": {
+        "@types/jsdom": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -266,17 +266,35 @@
         "@types/node": "*"
       }
     },
+    "abab": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
+      "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ=="
+    },
     "acorn": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
-      "dev": true
+      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      }
     },
     "acorn-jsx": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
+    },
+    "acorn-walk": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+      "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
     },
     "ajv": {
       "version": "6.12.4",
@@ -375,16 +393,52 @@
         "is-string": "^1.0.4"
       }
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+      "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -413,6 +467,11 @@
         "fill-range": "^7.0.1"
       }
     },
+    "browser-process-hrtime": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
+      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow=="
+    },
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
@@ -438,6 +497,11 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.2",
@@ -609,6 +673,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
+    },
     "commander": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
@@ -635,6 +707,11 @@
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
       "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -695,6 +772,26 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
       "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
     },
+    "cssom": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw=="
+    },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "requires": {
+        "cssom": "~0.3.6"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.3.8",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+          "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+        }
+      }
+    },
     "d": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -702,6 +799,24 @@
       "requires": {
         "es5-ext": "^0.10.50",
         "type": "^1.0.1"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "requires": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
       }
     },
     "debug": {
@@ -717,11 +832,15 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -730,6 +849,11 @@
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "diff": {
       "version": "4.0.2",
@@ -798,6 +922,21 @@
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
       "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
     },
+    "domexception": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+      "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+      "requires": {
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
+      }
+    },
     "domhandler": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.0.0.tgz",
@@ -814,6 +953,15 @@
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.0.1",
         "domhandler": "^3.0.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "emoji-regex": {
@@ -948,6 +1096,55 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escodegen": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
+      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "levn": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "requires": {
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2"
+          }
+        },
+        "optionator": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+          "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+          "requires": {
+            "deep-is": "~0.1.3",
+            "fast-levenshtein": "~2.0.6",
+            "levn": "~0.3.0",
+            "prelude-ls": "~1.1.2",
+            "type-check": "~0.3.2",
+            "word-wrap": "~1.2.3"
+          }
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "requires": {
+            "prelude-ls": "~1.1.2"
+          }
+        }
+      }
     },
     "eslint": {
       "version": "7.7.0",
@@ -1262,14 +1459,12 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -1295,6 +1490,16 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1314,8 +1519,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "file-entry-cache": {
       "version": "5.0.1",
@@ -1373,6 +1577,21 @@
       "resolved": "https://registry.npmjs.org/folktale/-/folktale-2.3.2.tgz",
       "integrity": "sha512-+8GbtQBwEqutP0v3uajDDoN64K2ehmHd0cjlghhxh0WpcfPzAIjPA03e1VvHlxL02FVGR0A6lwXsNQKn3H1RNQ=="
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1405,6 +1624,14 @@
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
       "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
       "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.6",
@@ -1446,6 +1673,20 @@
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA=="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "requires": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -1494,6 +1735,14 @@
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.0.4.tgz",
       "integrity": "sha512-VRdvxX3tmrXuT/Ovt59NMp/ORMFi4bceFMDjos1PV4E0mV+5votuID8R60egR9A4U8nLt238R/snlJGz3UYiTQ=="
     },
+    "html-encoding-sniffer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+      "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+      "requires": {
+        "whatwg-encoding": "^1.0.5"
+      }
+    },
     "htmlparser2": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
@@ -1503,6 +1752,24 @@
         "domhandler": "^3.0.0",
         "domutils": "^2.0.0",
         "entities": "^2.0.0"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "ignore": {
@@ -1540,6 +1807,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "is-arguments": {
       "version": "1.0.4",
@@ -1616,6 +1888,11 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c="
+    },
     "is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -1647,6 +1924,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -1656,6 +1938,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "iterate-iterator": {
       "version": "1.0.1",
@@ -1691,10 +1978,60 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
+    "jsdom": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
+      "integrity": "sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==",
+      "requires": {
+        "abab": "^2.0.3",
+        "acorn": "^7.1.1",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.2.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.0",
+        "domexception": "^2.0.1",
+        "escodegen": "^1.14.1",
+        "html-encoding-sniffer": "^2.0.1",
+        "is-potential-custom-element-name": "^1.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "5.1.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.8",
+        "saxes": "^5.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^3.0.1",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.1.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0",
+        "ws": "^7.2.3",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "parse5": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+          "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug=="
+        }
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-ref-parser": {
       "version": "9.0.6",
@@ -1746,6 +2083,17 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "juice": {
@@ -1807,6 +2155,11 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
@@ -1852,6 +2205,19 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
       "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+    },
+    "mime-db": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+    },
+    "mime-types": {
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "requires": {
+        "mime-db": "1.44.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1982,6 +2348,16 @@
       "requires": {
         "boolbase": "~1.0.0"
       }
+    },
+    "nwsapi": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
+    },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -2120,6 +2496,11 @@
       "requires": {
         "pify": "^2.0.0"
       }
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -2280,10 +2661,20 @@
         "iterate-value": "^1.0.0"
       }
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "quote": {
       "version": "0.4.0",
@@ -2409,6 +2800,73 @@
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
+      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
+      "requires": {
+        "lodash": "^4.17.19"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
+      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
+      "requires": {
+        "request-promise-core": "1.1.4",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
+      }
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -2447,6 +2905,19 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saxes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+      "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+      "requires": {
+        "xmlchars": "^2.2.0"
+      }
     },
     "semver": {
       "version": "7.3.2",
@@ -2611,6 +3082,12 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "optional": true
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -2648,10 +3125,31 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "stdin": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/stdin/-/stdin-0.0.1.tgz",
       "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "string-width": {
       "version": "2.1.1",
@@ -2728,6 +3226,11 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         }
       }
+    },
+    "symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "table": {
       "version": "5.4.6",
@@ -2813,6 +3316,24 @@
         "is-number": "^7.0.0"
       }
     },
+    "tough-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+      "requires": {
+        "ip-regex": "^2.1.0",
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tr46": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "requires": {
+        "punycode": "^2.1.1"
+      }
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
@@ -2824,6 +3345,19 @@
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type": {
       "version": "1.2.0",
@@ -2863,6 +3397,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.1.1",
@@ -2926,6 +3465,32 @@
         }
       }
     },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    },
+    "w3c-hr-time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
+      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "requires": {
+        "browser-process-hrtime": "^1.0.0"
+      }
+    },
+    "w3c-xmlserializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+      "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+      "requires": {
+        "xml-name-validator": "^3.0.0"
+      }
+    },
     "web-resource-inliner": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-5.0.0.tgz",
@@ -2937,6 +3502,41 @@
         "mime": "^2.4.6",
         "node-fetch": "^2.6.0",
         "valid-data-url": "^3.0.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w=="
+    },
+    "whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "requires": {
+        "iconv-lite": "0.4.24"
+      }
+    },
+    "whatwg-mimetype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
+    "whatwg-url": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
+      "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^2.0.2",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+        }
       }
     },
     "which": {
@@ -2963,8 +3563,7 @@
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
     "workerpool": {
       "version": "6.0.0",
@@ -3030,6 +3629,21 @@
           }
         }
       }
+    },
+    "ws": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw=="
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,23 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
+      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@bahmutov/data-driven": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@bahmutov/data-driven/-/data-driven-1.0.0.tgz",
@@ -49,10 +66,79 @@
         "lazy-ass": "1.6.0"
       }
     },
+    "@jest/types": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+      "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "@jsdevtools/ono": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
+    },
+    "@testing-library/dom": {
+      "version": "7.22.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.22.3.tgz",
+      "integrity": "sha512-IK6/eL1Xza/0goDKrwnBvlM06L+5eL9b1o+hUhX7HslfUvMETh0TYgXEr2LVpsVkHiOhRmUbUyml95KV/VlRNw==",
+      "requires": {
+        "@babel/runtime": "^7.10.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^4.2.2",
+        "dom-accessibility-api": "^0.5.1",
+        "pretty-format": "^25.5.0"
+      }
+    },
+    "@testing-library/preact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/preact/-/preact-2.0.0.tgz",
+      "integrity": "sha512-K54AYOnUzMcjK21+6XLfMyb6q8ngBVUXZkirjHMnUoqjarmCHmREzP539U0oKSszWSq7AJxu8M1EYD2YWAIneA==",
+      "requires": {
+        "@testing-library/dom": "^7.16.2"
+      }
+    },
+    "@types/aria-query": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.0.tgz",
+      "integrity": "sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A=="
     },
     "@types/chrome": {
       "version": "0.0.121",
@@ -96,6 +182,28 @@
       "integrity": "sha512-iUxzm1meBm3stxUMzRqgOVHjj4Kgpgu5w9fm4X7kPRfSgVRzythsucEN7/jtOo8SQzm+HfcxWWzJS0mJDH/3DQ==",
       "dev": true
     },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -135,6 +243,19 @@
       "resolved": "https://registry.npmjs.org/@types/tingle.js/-/tingle.js-0.13.1.tgz",
       "integrity": "sha512-Ke2Aza6HGg1v3dessXdNogGhyHNzTeYKDNLzGks7L0WnO4bPtIjuhIw2+23FR+IFWNzehTgeeDYbfhslU9Izhg==",
       "dev": true
+    },
+    "@types/yargs": {
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+      "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+      "integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
     },
     "@types/yazl": {
       "version": "2.4.2",
@@ -211,6 +332,15 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "@babel/runtime-corejs3": "^7.10.2"
       }
     },
     "array-includes": {
@@ -501,6 +631,11 @@
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -642,6 +777,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.1.tgz",
+      "integrity": "sha512-8DhtmKTYWXNpPiL/QOszbnkAbCGuPz9ieVwDrmWM1rNx4KRI3zqmvKANAD1PJdvvov3+eq1BPLXQkYTpqTrWng=="
     },
     "dom-serializer": {
       "version": "1.0.1",
@@ -2082,6 +2222,46 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "pretty-format": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+      "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+      "requires": {
+        "@jest/types": "^25.5.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        }
+      }
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2122,6 +2302,11 @@
       "requires": {
         "safe-buffer": "^5.1.0"
       }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -2212,6 +2397,11 @@
       "requires": {
         "picomatch": "^2.0.7"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regexpp": {
       "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2990,6 +2990,54 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "should": {
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
+      "requires": {
+        "should-equal": "^2.0.0",
+        "should-format": "^3.0.3",
+        "should-type": "^1.4.0",
+        "should-type-adaptors": "^1.0.1",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-equal": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
+      "integrity": "sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==",
+      "requires": {
+        "should-type": "^1.4.0"
+      }
+    },
+    "should-format": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+      "integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-type-adaptors": "^1.0.1"
+      }
+    },
+    "should-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+      "integrity": "sha1-B1bYzoRt/QmEOmlHcZ36DUz/XPM="
+    },
+    "should-type-adaptors": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
+      "integrity": "sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==",
+      "requires": {
+        "should-type": "^1.3.0",
+        "should-util": "^1.0.0"
+      }
+    },
+    "should-util": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
+      "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -204,6 +204,17 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jsdom": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.3.tgz",
+      "integrity": "sha512-BREatezSn74rmLIDksuqGNFUTi9HNAWWQXYpFBFLK9U6wlMCO4M0QCa8CMpDsZQuqxSO9XifVLT5Q1P0vgKLqw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/parse5": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
@@ -232,6 +243,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
       "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
     },
+    "@types/parse5": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
+      "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
+      "dev": true
+    },
     "@types/prettier": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.2.tgz",
@@ -242,6 +259,12 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@types/tingle.js/-/tingle.js-0.13.1.tgz",
       "integrity": "sha512-Ke2Aza6HGg1v3dessXdNogGhyHNzTeYKDNLzGks7L0WnO4bPtIjuhIw2+23FR+IFWNzehTgeeDYbfhslU9Izhg==",
+      "dev": true
+    },
+    "@types/tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
       "dev": true
     },
     "@types/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -304,6 +304,21 @@
       "integrity": "sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==",
       "dev": true
     },
+    "@types/sinon": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.5.tgz",
+      "integrity": "sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.1.tgz",
+      "integrity": "sha512-yYezQwGWty8ziyYLdZjwxyMb0CZR49h8JALHGrxjQHWlqGgc8kLdHEgWrgL0uZ29DMvEVBDnHU2Wg36zKSIUtA==",
+      "dev": true
+    },
     "@types/tingle.js": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/@types/tingle.js/-/tingle.js-0.13.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2046,6 +2046,11 @@
         }
       }
     },
+    "jsdom-global": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-3.0.2.tgz",
+      "integrity": "sha1-a9KZwTsMRiay2iwDk81DhdYGrLk="
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,46 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "@sinonjs/commons": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ=="
+    },
     "@testing-library/dom": {
       "version": "7.22.3",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.22.3.tgz",
@@ -2152,6 +2192,11 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA=="
+    },
     "lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
@@ -2191,6 +2236,11 @@
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
       "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -2347,6 +2397,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
+    },
+    "nise": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-fetch": {
       "version": "2.6.0",
@@ -2524,6 +2586,21 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
+      }
     },
     "path-type": {
       "version": "2.0.0",
@@ -3038,6 +3115,20 @@
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.1.tgz",
       "integrity": "sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g=="
     },
+    "sinon": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+      "requires": {
+        "@sinonjs/commons": "^1.7.2",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/samsam": "^5.1.0",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      }
+    },
     "slice-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
@@ -3457,6 +3548,11 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mustache": "^4.0.1",
     "preact": "^10.4.7",
     "should": "^13.2.3",
+    "should-sinon": "0.0.6",
     "sinon": "^9.0.3",
     "snap-shot-it": "^7.9.3",
     "tingle.js": "^0.15.3",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/mocha": "^8.0.3",
     "@types/mustache": "^4.0.1",
     "@types/prettier": "^2.0.2",
+    "@types/should-sinon": "0.0.6",
     "@types/sinon": "^9.0.5",
     "@types/tingle.js": "^0.13.1",
     "@types/yazl": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@types/chrome": "0.0.121",
     "@types/firefox-webext-browser": "^78.0.1",
+    "@types/jsdom": "^16.2.3",
     "@types/mocha": "^8.0.3",
     "@types/mustache": "^4.0.1",
     "@types/prettier": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ajv": "^6.12.4",
     "htm": "^3.0.4",
     "htmlparser2": "^4.1.0",
+    "jsdom": "^16.4.0",
     "json-schema-to-typescript": "^9.1.1",
     "juice": "^7.0.0",
     "microtip": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "homepage": "https://github.com/pastelmind/ruliweb-hots#readme",
   "dependencies": {
+    "@testing-library/preact": "^2.0.0",
     "ajv": "^6.12.4",
     "htm": "^3.0.4",
     "htmlparser2": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/chrome": "0.0.121",
     "@types/firefox-webext-browser": "^78.0.1",
     "@types/jsdom": "^16.2.3",
+    "@types/jsdom-global": "^3.0.2",
     "@types/mocha": "^8.0.3",
     "@types/mustache": "^4.0.1",
     "@types/prettier": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "mocha": "^8.1.1",
     "mustache": "^4.0.1",
     "preact": "^10.4.7",
+    "should": "^13.2.3",
     "snap-shot-it": "^7.9.3",
     "tingle.js": "^0.15.3",
     "yazl": "^2.5.1"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/mocha": "^8.0.3",
     "@types/mustache": "^4.0.1",
     "@types/prettier": "^2.0.2",
+    "@types/sinon": "^9.0.5",
     "@types/tingle.js": "^0.13.1",
     "@types/yazl": "^2.4.2",
     "commander": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "htm": "^3.0.4",
     "htmlparser2": "^4.1.0",
     "jsdom": "^16.4.0",
+    "jsdom-global": "^3.0.2",
     "json-schema-to-typescript": "^9.1.1",
     "juice": "^7.0.0",
     "microtip": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mustache": "^4.0.1",
     "preact": "^10.4.7",
     "should": "^13.2.3",
+    "sinon": "^9.0.3",
     "snap-shot-it": "^7.9.3",
     "tingle.js": "^0.15.3",
     "yazl": "^2.5.1"


### PR DESCRIPTION
Write tests for Preact components:

* \<HeroMenu\>
* \<HotsBoxMenu\>
* \<MultiSelectIcons\>

\<DialogContent\> is too complex for me to dare to touch it at this time. 😢

Install the following dependencies for writing tests:

* Preact Testing Library for user-friendly queries
* Sinon.js for spies
* jsdom for mocking the browser environment in Node.js
* Should.js for informative assertion messages
    * should-sinon for integration with Sinon.js

(Also add DefinitelyTyped type definitions for some of these packages)

While doing so, I have discovered several code regions that need refactoring.